### PR TITLE
Add htmlproofer link checking

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -34,6 +34,10 @@ jobs:
         with:
           source: ./
           destination: ./_site
+      - name: Check generated site for broken links
+        run: |
+          gem install html-proofer
+          htmlproofer ./_site
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
 


### PR DESCRIPTION
## Summary
- check for broken links with `htmlproofer` after building

## Testing
- `gem install html-proofer`
- `htmlproofer ./_site` *(fails: `./_site does not exist`)*

------
https://chatgpt.com/codex/tasks/task_e_68401f0646d0832d907109780fd220bd