### PR TITLE
Configure artifact path for Jekyll build

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -36,6 +36,8 @@ jobs:
           destination: ./_site
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./_site
 
   # Deployment job
   deploy:


### PR DESCRIPTION
## Summary
- upload `_site` directory when running Jekyll Pages workflow

## Testing
- `act --list` *(fails: couldn't connect to docker)*

------
https://chatgpt.com/codex/tasks/task_e_68401f035b8c832d9d5d994b7b691bdf