### PR TITLE
Fix capitalization in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claireity-SSIAM
 
-## A swift-based **S**elf-**S**ervice **I**dentity and **A**ccess **M**anagement application in development! 
+## A Swift-based **S**elf-**S**ervice **I**dentity and **A**ccess **M**anagement application in development!
 
 A white paper and proof of concept will be published soon, I'm a solo-dev with very little time on my hands... 
 Meanwhile, you can check out the very first wireframe & presentation of the application, giving more insight into the project!


### PR DESCRIPTION
## Summary
- capitalize Swift in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68401f04bad0832db88e35c5281a7aa3