### PR TITLE
Fix failing GitHub Pages build

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -39,7 +39,7 @@ jobs:
           gem install html-proofer
           htmlproofer ./_site
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./_site
 


### PR DESCRIPTION
## Summary
- use latest `upload-pages-artifact` action to avoid missing artifact issue

## Testing
- `yamllint .github/workflows/jekyll-gh-pages.yml`

------
https://chatgpt.com/codex/tasks/task_e_6840286704b4832db340d813f8dcbf3a